### PR TITLE
(Hotfix)  Arrowheads for direct association and generalization association should be different 

### DIFF
--- a/lib/lutaml/formatter/graphviz.rb
+++ b/lib/lutaml/formatter/graphviz.rb
@@ -179,7 +179,7 @@ module Lutaml
                                     "onormal"
                                   end
         # swap labels and arrows if `dir` eq to `back`
-        if attributes["dir"] == "back"
+        if attributes["dir"] == "back" && attributes["arrowtail"] != "vee"
           attributes["arrowhead"], attributes["arrowtail"] =
             [attributes["arrowtail"], attributes["arrowhead"]]
           attributes["headlabel"], attributes["taillabel"] =


### PR DESCRIPTION
https://github.com/lutaml/lutaml-uml/issues/73 fix wrong direct display