### PR TITLE
[WIP] feat: add single-line association syntax and DSL export

### DIFF
--- a/docs/_references/formats/lutaml-syntax.adoc
+++ b/docs/_references/formats/lutaml-syntax.adoc
@@ -79,18 +79,17 @@ where:
 * `owner_type` - optional, type of the owner end (`aggregation`|`composition`|`direct`|`inheritance`)
 * `member_type` - optional, type of the member end (`aggregation`|`composition`|`direct`|`inheritance`)
 * `owner|member` - end of association, use `\#attribute_name` to set a role name
-* `property_string` - property string for attibutes associations
-* `cardinality` - examples: '1..*', '*'
+* `cardinality` - optional, in square brackets, e.g. `[1..*]`, `[0..*]`, `[*]`
 
 Example:
 
 [source,java]
 ----
 class AddressClassProfile {
-  +addressClassProfile:
+  +addressClassProfile
 }
 class AttributeProfile {
-  +attributeProfile:
+  +attributeProfile
 }
 
 association BidirectionalAssociation {

--- a/docs/_references/formats/lutaml-syntax.adoc
+++ b/docs/_references/formats/lutaml-syntax.adoc
@@ -67,18 +67,18 @@ Syntax:
 [source,java]
 ----
 association name {
-  owned_type association|composition|aggregation|generalization|uses
-  member_type association|composition|aggregation|generalization|uses
-  owned association_name[#attribute_name] [{property_string}][cardinality]
-  member association_name[#attribute_name] [{property_string}][cardinality]
+  owner_type aggregation|composition|direct|inheritance
+  member_type aggregation|composition|direct|inheritance
+  owner association_name[#attribute_name] [cardinality]
+  member association_name[#attribute_name] [cardinality]
 }
 ----
 
 where:
 
-* `owned_type` - optional, use to define a bidirectional association (`association`|`composition`|`aggregation`|`generalization`|`uses`)
-* `member_type` - association type (`association`|`composition`|`aggregation`|`generalization`|`uses`)
-* `owned|member` - end of association, use `\#attribute_name` to set a role name
+* `owner_type` - optional, type of the owner end (`aggregation`|`composition`|`direct`|`inheritance`)
+* `member_type` - optional, type of the member end (`aggregation`|`composition`|`direct`|`inheritance`)
+* `owner|member` - end of association, use `\#attribute_name` to set a role name
 * `property_string` - property string for attibutes associations
 * `cardinality` - examples: '1..*', '*'
 
@@ -86,31 +86,50 @@ Example:
 
 [source,java]
 ----
-class Association {
-  +association:
+class AddressClassProfile {
+  +addressClassProfile:
 }
-class Type {
-  +endType:
+class AttributeProfile {
+  +attributeProfile:
 }
 
-association AssociatingTypeAndAssociation {
-  type uses
-  from Association#+association {subsets relationship}[*]
-  to Type#+/endType {readOnly, subsets relatedElement} [1..*]
+association BidirectionalAssociation {
+  owner_type aggregation
+  member_type direct
+  owner AddressClassProfile#addressClassProfile
+  member AttributeProfile#attributeProfile [0..*]
 }
 ----
 
-=== Undirected associations
+=== Single-line associations
 
-The simplest way to define relationship between two classes is to use `generalize` keyword:
+A relationship between two classes can be written on a single line using
+PlantUML-style operators, as a shorthand for the explicit `association { }`
+block:
 
 [source,java]
 ----
-class Pet {}
-class Cat {
-  generalize Pet
-}
+A --> B       // directed association (navigable to B)
+A o-- B       // aggregation (B is shared-owned by A)
+A *-- B       // composition (B is part of A)
+A --|> B      // generalization (A is a kind of B)
+A -- B        // plain association
 ----
+
+The operator desugars to the same `owner_type`/`member_type` ends as the block
+form: the left adornment sets the owner end and the right adornment sets the
+member end, so the two can be combined — e.g. `A o--> B` is an aggregation on
+A's end together with a navigable arrow on B's end. Role names and cardinality
+are optional on either end:
+
+[source,java]
+----
+Order#orders --> Customer#customer [1..*]
+----
+
+Whitespace around the operator is required — write `A --> B`, not `A-->B`.
+(The aggregation glyph `o` is also a name character, so a spaceless form would
+be ambiguous.)
 
 === Attribute relationship
 

--- a/lib/lutaml/converter.rb
+++ b/lib/lutaml/converter.rb
@@ -3,6 +3,7 @@
 module Lutaml
   module Converter
     autoload :DslToUml, "lutaml/converter/dsl_to_uml"
+    autoload :UmlToDsl, "lutaml/converter/uml_to_dsl"
     autoload :XmiToUmlGeneralization,
              "lutaml/converter/xmi_to_uml_generalization"
     autoload :XmiToUml, "lutaml/converter/xmi_to_uml"

--- a/lib/lutaml/converter/dsl_to_uml.rb
+++ b/lib/lutaml/converter/dsl_to_uml.rb
@@ -97,7 +97,9 @@ module Lutaml
       def set_model_attribute(model, hash) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
         hash.each do |key, value|
           if key == :definition
-            value = value.to_s.gsub(/\\}/, "}").gsub(/\\{/, "{")
+            # Single-pass unescape of \\, \{ and \} (mirrors UmlToDsl escaping),
+            # so a leading backslash cannot swallow a following brace.
+            value = value.to_s.gsub(/\\([\\{}])/, '\1')
               .split("\n").map(&:strip).join("\n")
           end
 

--- a/lib/lutaml/converter/uml_to_dsl.rb
+++ b/lib/lutaml/converter/uml_to_dsl.rb
@@ -160,7 +160,9 @@ module Lutaml
       end
 
       def definition_block(text)
-        escaped = text.to_s.gsub("{", "\\{").gsub("}", "\\}")
+        # Escape the escape character itself (\) as well as the braces, so any
+        # definition text round-trips through the parser's unescaping.
+        escaped = text.to_s.gsub(/[\\{}]/) { |char| "\\#{char}" }
         "definition {\n#{escaped}\n}"
       end
 

--- a/lib/lutaml/converter/uml_to_dsl.rb
+++ b/lib/lutaml/converter/uml_to_dsl.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Converter
+    # Serializes a Lutaml::Uml::Document back into LutaML DSL (.lutaml) text.
+    #
+    # This is the structural inverse of Lutaml::Converter::DslToUml: the emitted
+    # text re-parses through Lutaml::Uml::Parsers::Dsl into a Document that is
+    # structurally equivalent to the input (classes, attributes, enums,
+    # data types, primitives and associations). It is not byte-identical to the
+    # original source — whitespace is normalised and associations are emitted in
+    # the explicit `association { }` block form.
+    #
+    # SCOPE: this targets documents that the LutaML DSL can represent (i.e.
+    # DSL-authored documents, round-tripped). It deliberately does NOT emit
+    # content that only originates from XMI/QEA imports and has no DSL
+    # construct: package nesting (Document#packages), enum literals stored in
+    # Enum#values (vs DSL enum members, which are attributes), or names/strings
+    # containing characters the grammar does not accept. Exporting those is a
+    # separate, fuller UML->DSL export effort.
+    #
+    # It also does not yet emit element comments (TopElement#comments /
+    # Document#comments); comments are dropped on export. Re-emitting them is a
+    # follow-up.
+    module UmlToDsl
+      module_function
+
+      # Maps a model visibility to its DSL prefix symbol. "public" emits an
+      # explicit `+` (the parser records implicit/no-prefix attributes as a nil
+      # visibility, so emitting nothing would lose an explicit `public`).
+      VISIBILITY_SYMBOL = {
+        "private" => "-",
+        "protected" => "#",
+        "friendly" => "~",
+        "public" => "+",
+      }.freeze
+
+      def convert(document)
+        body = document_header(document)
+        body.concat(elements_to_dsl(document))
+        "#{block("diagram #{document.name || 'Document'}", body)}\n"
+      end
+
+      def document_header(document)
+        header = []
+        header << "title \"#{document.title}\"" if present?(document.title)
+        header << "caption \"#{document.caption}\"" if present?(document.caption)
+        header << "fontname \"#{document.fontname}\"" if present?(document.fontname)
+        header
+      end
+
+      def elements_to_dsl(document) # rubocop:disable Metrics/AbcSize
+        document.classes.to_a.map { |element| class_to_dsl(element) } +
+          document.enums.to_a.map { |element| enum_to_dsl(element) } +
+          document.data_types.to_a.map { |element| data_type_to_dsl(element) } +
+          document.primitives.to_a.map { |element| "primitive #{element.name}" } +
+          document.associations.to_a.map { |element| association_to_dsl(element) }
+      end
+
+      def class_to_dsl(klass)
+        header = "class #{klass.name}"
+        header = "#{klass.modifier} #{header}" if present?(klass.modifier)
+        header += " <<#{klass.keyword}>>" if present?(klass.keyword)
+        block(header, classifier_body(klass))
+      end
+
+      def enum_to_dsl(enum)
+        block("enum #{enum.name}", classifier_body(enum))
+      end
+
+      def data_type_to_dsl(data_type)
+        block("data_type #{data_type.name}", classifier_body(data_type))
+      end
+
+      # Shared body for class/enum/data_type: optional definition + attributes.
+      def classifier_body(element)
+        body = []
+        body << definition_block(element.definition) if present?(element.definition)
+        element.attributes.to_a.each { |attr| body << attribute_to_dsl(attr) }
+        body
+      end
+
+      def attribute_to_dsl(attr)
+        line = attribute_signature(attr)
+        return line unless present?(attr.definition)
+
+        # An attribute with a definition is emitted with a body block so the
+        # definition round-trips (the grammar allows an attribute body).
+        block(line, [definition_block(attr.definition)])
+      end
+
+      def attribute_signature(attr)
+        line = "#{visibility_symbol(attr.visibility)}#{attr.name}"
+        line += attribute_type_suffix(attr) if present?(attr.type)
+        line += " #{cardinality_to_dsl(attr.cardinality)}" if cardinality?(attr.cardinality)
+        line
+      end
+
+      def attribute_type_suffix(attr)
+        suffix = ": "
+        suffix += "<<#{attr.keyword}>> " if present?(attr.keyword)
+        suffix + attr.type
+      end
+
+      def visibility_symbol(visibility)
+        VISIBILITY_SYMBOL.fetch(visibility.to_s, "")
+      end
+
+      def association_to_dsl(assoc)
+        header = present?(assoc.name) ? "association #{assoc.name}" : "association"
+        block(header, association_body(assoc))
+      end
+
+      def association_body(assoc)
+        [
+          ("owner_type #{assoc.owner_end_type}" if present?(assoc.owner_end_type)),
+          ("member_type #{assoc.member_end_type}" if present?(assoc.member_end_type)),
+          ("owner #{owner_ref(assoc)}" if present?(assoc.owner_end)),
+          ("member #{member_ref(assoc)}" if present?(assoc.member_end)),
+        ].compact
+      end
+
+      def owner_ref(assoc)
+        end_ref(assoc.owner_end, assoc.owner_end_attribute_name,
+                assoc.owner_end_cardinality)
+      end
+
+      def member_ref(assoc)
+        end_ref(assoc.member_end, assoc.member_end_attribute_name,
+                assoc.member_end_cardinality)
+      end
+
+      def end_ref(name, attribute_name, cardinality)
+        # dup: `name` is the model's own (unfrozen) string; building on a copy
+        # avoids mutating assoc.owner_end / member_end in place.
+        ref = name.to_s.dup
+        ref += "##{attribute_name}" if present?(attribute_name)
+        ref += " #{cardinality_to_dsl(cardinality)}" if cardinality?(cardinality)
+        ref
+      end
+
+      def cardinality_to_dsl(cardinality)
+        return "[#{cardinality.min}..#{cardinality.max}]" if present?(cardinality.max)
+
+        "[#{cardinality.min}]"
+      end
+
+      def definition_block(text)
+        escaped = text.to_s.gsub("{", "\\{").gsub("}", "\\}")
+        "definition {\n#{escaped}\n}"
+      end
+
+      # Wraps `header` around an indented body. Multi-line body entries (e.g. a
+      # nested definition block) are indented line by line.
+      def block(header, body_entries)
+        return "#{header} {}" if body_entries.empty?
+
+        inner = body_entries
+          .flat_map { |entry| entry.split("\n") }
+          .map { |line| line.empty? ? line : "  #{line}" }
+          .join("\n")
+        "#{header} {\n#{inner}\n}"
+      end
+
+      def cardinality?(cardinality)
+        cardinality && present?(cardinality.min)
+      end
+
+      def present?(value)
+        value && !value.to_s.strip.empty?
+      end
+    end
+  end
+end

--- a/lib/lutaml/converter/uml_to_dsl.rb
+++ b/lib/lutaml/converter/uml_to_dsl.rb
@@ -22,6 +22,12 @@ module Lutaml
     # It also does not yet emit element comments (TopElement#comments /
     # Document#comments); comments are dropped on export. Re-emitting them is a
     # follow-up.
+    #
+    # Definition text is emitted verbatim (only `\`, `{` and `}` are escaped),
+    # so a definition containing `//` or a line whose first word is `include`
+    # does NOT round-trip: the DSL preprocessor strips `//` comments and expands
+    # `include` directives before parsing, independent of this exporter. Making
+    # the preprocessor definition/quote-aware is a follow-up.
     module UmlToDsl
       module_function
 
@@ -74,16 +80,25 @@ module Lutaml
       def class_to_dsl(klass)
         header = "class #{klass.name}"
         header = "#{klass.modifier} #{header}" if present?(klass.modifier)
-        header += " <<#{klass.keyword}>>" if present?(klass.keyword)
-        block(header, classifier_body(klass))
+        block(with_keyword(header, klass), classifier_body(klass))
       end
 
       def enum_to_dsl(enum)
-        block("enum #{enum.name}", classifier_body(enum))
+        block(with_keyword("enum #{enum.name}", enum), classifier_body(enum))
       end
 
       def data_type_to_dsl(data_type)
-        block("data_type #{data_type.name}", classifier_body(data_type))
+        block(with_keyword("data_type #{data_type.name}", data_type),
+              classifier_body(data_type))
+      end
+
+      # Appends a `<<keyword>>` stereotype to a classifier header. The grammar
+      # accepts it on classes, enums and data types, so all three must re-emit
+      # it to round-trip.
+      def with_keyword(header, element)
+        return header unless present?(element.keyword)
+
+        "#{header} <<#{element.keyword}>>"
       end
 
       # Shared body for class/enum/data_type: optional definition + attributes.

--- a/lib/lutaml/converter/uml_to_dsl.rb
+++ b/lib/lutaml/converter/uml_to_dsl.rb
@@ -43,10 +43,24 @@ module Lutaml
 
       def document_header(document)
         header = []
-        header << "title \"#{document.title}\"" if present?(document.title)
-        header << "caption \"#{document.caption}\"" if present?(document.caption)
+        header << "title #{dsl_quote(document.title)}" if present?(document.title)
+        if present?(document.caption)
+          header << "caption #{dsl_quote(document.caption)}"
+        end
         header << "fontname \"#{document.fontname}\"" if present?(document.fontname)
         header
+      end
+
+      # Quote a title/caption so it round-trips through the DSL grammar. Prefers
+      # double quotes; switches to single quotes when the value contains a
+      # double quote; if it contains both (the DSL has no escape), drops the
+      # double quotes so the output still parses.
+      def dsl_quote(value)
+        str = value.to_s
+        return "\"#{str}\"" unless str.include?('"')
+        return "'#{str}'" unless str.include?("'")
+
+        "\"#{str.delete('"')}\""
       end
 
       def elements_to_dsl(document) # rubocop:disable Metrics/AbcSize

--- a/lib/lutaml/uml/document.rb
+++ b/lib/lutaml/uml/document.rb
@@ -59,6 +59,13 @@ module Lutaml
 
         model.associations = associations
       end
+
+      # Serialize this document back into LutaML DSL (.lutaml) text.
+      # Inverse of parsing; output re-parses to a structurally equivalent
+      # Document. See Lutaml::Converter::UmlToDsl.
+      def to_lutaml
+        Lutaml::Converter::UmlToDsl.convert(self)
+      end
     end
   end
 end

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -215,6 +215,12 @@ module Lutaml
 
         rule(:association_keyword) { kw_association >> spaces }
 
+        # Association end and role names accept the same extra characters as
+        # the one-line shorthand endpoints (':' and '.', for qualified names
+        # like Foo::Bar), so any association the shorthand parses can be
+        # re-emitted through the block form (Document#to_lutaml) and re-parsed.
+        rule(:assoc_end_name) { match['a-zA-Z0-9 _\-:.'].repeat(1) }
+
         %w[owner member].each do |association_end_type| # rubocop:disable Metrics/BlockLength
           rule("#{association_end_type}_cardinality") do
             spaces? >>
@@ -229,7 +235,7 @@ module Lutaml
           rule("#{association_end_type}_attribute_name") do
             str("#") >>
               visibility? >>
-              name.as("#{association_end_type}_end_attribute_name")
+              assoc_end_name.as("#{association_end_type}_end_attribute_name")
           end
           rule("#{association_end_type}_attribute_name?") do
             send(:"#{association_end_type}_attribute_name").maybe
@@ -237,7 +243,7 @@ module Lutaml
           rule("#{association_end_type}_definition") do
             send(:"kw_#{association_end_type}") >>
               spaces >>
-              name.as("#{association_end_type}_end") >>
+              assoc_end_name.as("#{association_end_type}_end") >>
               send(:"#{association_end_type}_attribute_name?") >>
               send(:"#{association_end_type}_cardinality?")
           end

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -150,19 +150,28 @@ module Lutaml
         end
 
         rule(:title_keyword) { kw_title >> spaces }
-        rule(:title_text) do
-          match['"\''].maybe >>
-            match['a-zA-Z0-9_\- ,.:;'].repeat(1).as(:title) >>
-            match['"\''].maybe
-        end
+        rule(:title_text) { quoted_or_plain_text(:title) }
         rule(:title_definition) { title_keyword >> title_text }
         rule(:caption_keyword) { kw_caption >> spaces }
-        rule(:caption_text) do
-          match['"\''].maybe >>
-            match['a-zA-Z0-9_\- ,.:;'].repeat(1).as(:caption) >>
-            match['"\''].maybe
-        end
+        rule(:caption_text) { quoted_or_plain_text(:caption) }
         rule(:caption_definition) { caption_keyword >> caption_text }
+
+        # A quoted string (any content except its quote char or a newline) or,
+        # for backward compatibility, an unquoted run of name-ish characters.
+        # The quoted form lets titles/captions carry parens, slashes, etc. and
+        # still round-trip through Document#to_lutaml.
+        def quoted_or_plain_text(key)
+          quoted_text('"', key) |
+            quoted_text("'", key) |
+            match['a-zA-Z0-9_\- ,.:;'].repeat(1).as(key)
+        end
+
+        def quoted_text(quote, key)
+          line_break = str("\n") | str("\r")
+          str(quote) >>
+            ((str(quote) | line_break).absent? >> any).repeat(1).as(key) >>
+            str(quote)
+        end
 
         rule(:fontname_keyword) { kw_fontname >> spaces }
         rule(:fontname_text) do
@@ -287,7 +296,12 @@ module Lutaml
           rule("shortcut_#{end_type}_endpoint") do
             endpoint_name_chars.as("#{end_type}_end") >>
               (str("#") >>
-                visibility? >>
+                # Consume an optional visibility marker (+/-/#/~) on the role
+                # name WITHOUT capturing it: the Association model has no role
+                # visibility, and capturing it as :visibility_modifier on both
+                # ends collides ("Duplicate subtrees") when owner and member are
+                # merged into the single assoc_shortcut subtree.
+                kw_visibility_modifier.maybe >>
                 endpoint_name_chars.as("#{end_type}_end_attribute_name")).maybe >>
               (spaces? >>
                 str("[") >>
@@ -295,13 +309,17 @@ module Lutaml
                 str("]")).maybe
           end
         end
+        # Horizontal whitespace (space or tab) — the shared `spaces` rule only
+        # matches the space byte, so the operator separator uses this to accept
+        # tabs too.
+        rule(:hspace) { (str(" ") | str("\t")).repeat(1) }
         # NOTE: whitespace around the operator is REQUIRED. The aggregation
         # glyph `o` is also a name character, so a spaceless form like
         # `Foo-->Bar` would mis-parse (`Foo`'s trailing `o` consumed as an
-        # `o--` adornment). Mandatory spaces make the operator unambiguous.
+        # `o--` adornment). Mandatory whitespace makes the operator unambiguous.
         rule(:shortcut_association_definition) do
           (shortcut_owner_endpoint >>
-            spaces >> assoc_op >> spaces >>
+            hspace >> assoc_op >> hspace >>
             shortcut_member_endpoint)
             .as(:assoc_shortcut)
         end

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -263,6 +263,49 @@ module Lutaml
             association_body
         end
 
+        # -- Association shorthand (one-line, PlantUML-style operators)
+        #
+        # Compositional operator: [left adornment] -- [right adornment]
+        #   left  -> owner_end_type, right -> member_end_type
+        #   *  composition   o  aggregation   <| / |>  inheritance   < / >  direct
+        # Examples: A --> B | A o-- B | A o--> B | A --|> B | A *-- B | A -- B
+        rule(:assoc_op_left)  { str("*") | str("o") | str("<|") | str("<") }
+        rule(:assoc_op_right) { str("*") | str("o") | str("|>") | str(">") }
+        rule(:assoc_op) do
+          assoc_op_left.as(:op_left).maybe >>
+            str("--") >>
+            assoc_op_right.as(:op_right).maybe
+        end
+        # Operator-aware endpoint token: like a class name but whitespace-free,
+        # and it stops before an operator so `Test-Class --> Other` parses while
+        # `A-->B` splits correctly (a `-`/`:`/`.` is part of the name only when
+        # it does not begin an operator).
+        rule(:endpoint_name_chars) do
+          (assoc_op.absent? >> match['a-zA-Z0-9_\-:.']).repeat(1)
+        end
+        %w[owner member].each do |end_type|
+          rule("shortcut_#{end_type}_endpoint") do
+            endpoint_name_chars.as("#{end_type}_end") >>
+              (str("#") >>
+                visibility? >>
+                endpoint_name_chars.as("#{end_type}_end_attribute_name")).maybe >>
+              (spaces? >>
+                str("[") >>
+                cardinality_body_definition.as("#{end_type}_end_cardinality") >>
+                str("]")).maybe
+          end
+        end
+        # NOTE: whitespace around the operator is REQUIRED. The aggregation
+        # glyph `o` is also a name character, so a spaceless form like
+        # `Foo-->Bar` would mis-parse (`Foo`'s trailing `o` consumed as an
+        # `o--` adornment). Mandatory spaces make the operator unambiguous.
+        rule(:shortcut_association_definition) do
+          (shortcut_owner_endpoint >>
+            spaces >> assoc_op >> spaces >>
+            shortcut_member_endpoint)
+            .as(:assoc_shortcut)
+        end
+
         # -- Class
 
         rule(:kw_class_modifier) { kw_abstract | kw_interface }
@@ -384,6 +427,7 @@ module Lutaml
             primitive_definition.as(:primitives) |
             data_type_definition.as(:data_types) |
             association_definition.as(:associations) |
+            shortcut_association_definition |
             comment_definition |
             comment_multiline_definition
         end

--- a/lib/lutaml/uml/parsers/dsl_transform.rb
+++ b/lib/lutaml/uml/parsers/dsl_transform.rb
@@ -8,6 +8,37 @@ module Lutaml
       # Class for additional transformations of LutaML syntax:
       # visibility modifier etc
       class DslTransform < Parslet::Transform
+        # Maps one-line association operator adornments to end-type values.
+        # Left adornment -> owner_end_type, right adornment -> member_end_type.
+        OWNER_OP_TYPE = {
+          "*" => "composition", "o" => "aggregation",
+          "<|" => "inheritance", "<" => "direct"
+        }.freeze
+        MEMBER_OP_TYPE = {
+          "*" => "composition", "o" => "aggregation",
+          "|>" => "inheritance", ">" => "direct"
+        }.freeze
+
+        # Desugar a one-line association shorthand subtree into the same
+        # `{ associations: { ... } }` hash the verbose `association { }` block
+        # produces, so the converter (DslToUml) needs no changes.
+        rule(assoc_shortcut: subtree(:parts)) do
+          src = parts.is_a?(Hash) ? parts : {}
+          assoc = {}
+          %w[owner_end member_end
+             owner_end_attribute_name member_end_attribute_name
+             owner_end_cardinality member_end_cardinality].each do |key|
+            assoc[key] = src[key] if src[key]
+          end
+          if (left = src[:op_left])
+            assoc["owner_end_type"] = OWNER_OP_TYPE[left.to_s]
+          end
+          if (right = src[:op_right])
+            assoc["member_end_type"] = MEMBER_OP_TYPE[right.to_s]
+          end
+          { associations: assoc }
+        end
+
         rule(visibility_modifier: simple(:visibility_value)) do
           case visibility_value
           when "-"

--- a/spec/fixtures/dsl/diagram_class_association_shorthand.lutaml
+++ b/spec/fixtures/dsl/diagram_class_association_shorthand.lutaml
@@ -1,0 +1,16 @@
+diagram ShorthandView {
+  class A {}
+  class B {}
+
+  A --> B
+  A o-- B
+  A *-- B
+  A --|> B
+  A o--> B
+  A -- B
+  A <-- B
+  A <|-- B
+  A --o B
+  A#owns [1] --> B#owned [0..*]
+  Foo::Bar --> Baz::Qux
+}

--- a/spec/fixtures/dsl/diagram_roundtrip_rich.lutaml
+++ b/spec/fixtures/dsl/diagram_roundtrip_rich.lutaml
@@ -35,7 +35,7 @@ diagram RichView {
   association PersonAnimal {
     owner_type aggregation
     member_type direct
-    owner Person#pets
+    owner Person#pets [1..*]
     member Animal#owner [0..*]
   }
 }

--- a/spec/fixtures/dsl/diagram_roundtrip_rich.lutaml
+++ b/spec/fixtures/dsl/diagram_roundtrip_rich.lutaml
@@ -1,0 +1,41 @@
+diagram RichView {
+  title "rich round-trip"
+
+  class Person {
+    definition {
+      A human being.
+    }
+    +name: String [1]
+    -age: Integer
+    +email: String [0..1]
+    +ssn: String {
+      definition {
+        Social security number.
+      }
+    }
+  }
+
+  abstract class Animal {
+    +species: String
+  }
+
+  enum Color {
+    red
+    green
+    blue
+  }
+
+  data_type Money {
+    +amount: Integer
+    +currency: String [1]
+  }
+
+  primitive Boolean
+
+  association PersonAnimal {
+    owner_type aggregation
+    member_type direct
+    owner Person#pets
+    member Animal#owner [0..*]
+  }
+}

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
     end
   end
 
+  describe "title and caption round-trip" do
+    it "preserves titles and captions with special characters",
+       :aggregate_failures do
+      doc = Lutaml::Uml::Document.new(name: "M")
+      doc.title = "Core (v1.2) / urf"
+      doc.caption = "needs a \"quote\" inside"
+
+      reparsed = reparse(doc.to_lutaml)
+
+      expect(reparsed.title).to eq("Core (v1.2) / urf")
+      expect(reparsed.caption).to eq("needs a \"quote\" inside")
+    end
+  end
+
   describe "rich round-trip" do
     let(:fixture) { fixtures_path("dsl/diagram_roundtrip_rich.lutaml") }
 

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tempfile"
+
+RSpec.describe Lutaml::Converter::UmlToDsl do
+  let(:fixture) { fixtures_path("dsl/diagram_class_assocation.lutaml") }
+  let(:document) { Lutaml::Uml::Parsers::Dsl.parse(File.new(fixture)) }
+
+  def reparse(dsl_string)
+    file = Tempfile.new(["uml_to_dsl", ".lutaml"])
+    file.write(dsl_string)
+    file.flush
+    Lutaml::Uml::Parsers::Dsl.parse(File.new(file.path))
+  ensure
+    file&.close
+    file&.unlink
+  end
+
+  def association_tuples(doc)
+    doc.associations.map do |a|
+      [a.owner_end, a.owner_end_type, a.owner_end_attribute_name,
+       a.member_end, a.member_end_type, a.member_end_attribute_name,
+       a.member_end_cardinality&.min, a.member_end_cardinality&.max, a.name]
+    end
+  end
+
+  describe "Document#to_lutaml" do
+    it "emits LutaML DSL that re-parses without error" do
+      expect { reparse(document.to_lutaml) }.not_to raise_error
+    end
+
+    it "round-trips the document structurally", :aggregate_failures do
+      reparsed = reparse(document.to_lutaml)
+
+      expect(reparsed.name).to eq(document.name)
+      expect(reparsed.title).to eq(document.title)
+      expect(reparsed.classes.map(&:name)).to eq(document.classes.map(&:name))
+      expect(reparsed.classes.map { |c| c.attributes.to_a.map(&:name) })
+        .to eq(document.classes.map { |c| c.attributes.to_a.map(&:name) })
+      expect(association_tuples(reparsed)).to eq(association_tuples(document))
+    end
+
+    it "does not mutate the source document" do
+      before = association_tuples(document)
+      document.to_lutaml
+      expect(association_tuples(document)).to eq(before)
+    end
+  end
+
+  describe "rich round-trip" do
+    let(:fixture) { fixtures_path("dsl/diagram_roundtrip_rich.lutaml") }
+
+    def attribute_tuples(klass)
+      klass.attributes.to_a.map do |a|
+        [a.name, a.visibility, a.type,
+         a.cardinality&.min, a.cardinality&.max, a.definition]
+      end
+    end
+
+    it "preserves attributes, visibility, types, cardinality and definitions",
+       :aggregate_failures do
+      reparsed = reparse(document.to_lutaml)
+
+      original = document.classes.map { |c| [c.name, c.modifier, c.definition, attribute_tuples(c)] }
+      roundtripped = reparsed.classes.map { |c| [c.name, c.modifier, c.definition, attribute_tuples(c)] }
+      expect(roundtripped).to eq(original)
+      # guards the attribute-definition emission specifically
+      ssn = reparsed.classes.find { |c| c.name == "Person" }.attributes.find { |a| a.name == "ssn" }
+      expect(ssn.definition).to eq("Social security number.")
+    end
+
+    it "preserves enums, data types and primitives", :aggregate_failures do
+      reparsed = reparse(document.to_lutaml)
+
+      expect(reparsed.enums.map { |e| [e.name, e.attributes.to_a.map(&:name)] })
+        .to eq(document.enums.map { |e| [e.name, e.attributes.to_a.map(&:name)] })
+      expect(reparsed.data_types.map { |d| d.attributes.to_a.map(&:name) })
+        .to eq(document.data_types.map { |d| d.attributes.to_a.map(&:name) })
+      expect(reparsed.primitives.map(&:name))
+        .to eq(document.primitives.map(&:name))
+      expect(association_tuples(reparsed)).to eq(association_tuples(document))
+    end
+  end
+end

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -108,4 +108,23 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
       expect(reparsed.classes.first.definition).to eq(tricky)
     end
   end
+
+  describe "classifier keyword round-trip" do
+    it "preserves <<keyword>> on enums and data types", :aggregate_failures do
+      src = <<~LUTAML
+        diagram D {
+          enum Color <<enumeration>> {
+            red
+          }
+          data_type Money <<valueType>> {
+            amount
+          }
+        }
+      LUTAML
+      reparsed = reparse(reparse(src).to_lutaml)
+
+      expect(reparsed.enums.first.keyword).to eq("enumeration")
+      expect(reparsed.data_types.first.keyword).to eq("valueType")
+    end
+  end
 end

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
       expect(reparsed.title).to eq("Core (v1.2) / urf")
       expect(reparsed.caption).to eq("needs a \"quote\" inside")
     end
+
+    it "drops double quotes from a value containing both quote kinds" do
+      # The DSL grammar has no escape sequence, so a value holding both `"`
+      # and `'` cannot be emitted losslessly. dsl_quote deletes the double
+      # quotes to keep the output parseable — a deliberate tradeoff.
+      doc = Lutaml::Uml::Document.new(name: "M")
+      doc.title = %q(a "double" and a 'single')
+
+      reparsed = reparse(doc.to_lutaml)
+
+      expect(reparsed.title).to eq("a double and a 'single'")
+    end
   end
 
   describe "rich round-trip" do

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -20,9 +20,14 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
   def association_tuples(doc)
     doc.associations.map do |a|
       [a.owner_end, a.owner_end_type, a.owner_end_attribute_name,
+       *card(a.owner_end_cardinality),
        a.member_end, a.member_end_type, a.member_end_attribute_name,
-       a.member_end_cardinality&.min, a.member_end_cardinality&.max, a.name]
+       *card(a.member_end_cardinality), a.name]
     end
+  end
+
+  def card(cardinality)
+    [cardinality&.min, cardinality&.max]
   end
 
   describe "Document#to_lutaml" do

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -116,9 +116,12 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
 
   describe "classifier keyword round-trip" do
     it "preserves <<keyword>> on enums and data types", :aggregate_failures do
+      # Deliberately NON-default keywords: Enum defaults keyword to
+      # "enumeration", so asserting the default would pass even if the
+      # exporter dropped the keyword entirely.
       src = <<~LUTAML
         diagram D {
-          enum Color <<enumeration>> {
+          enum Color <<colours>> {
             red
           }
           data_type Money <<valueType>> {
@@ -128,8 +131,27 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
       LUTAML
       reparsed = reparse(reparse(src).to_lutaml)
 
-      expect(reparsed.enums.first.keyword).to eq("enumeration")
+      expect(reparsed.enums.first.keyword).to eq("colours")
       expect(reparsed.data_types.first.keyword).to eq("valueType")
+    end
+  end
+
+  describe "qualified and dotted association names round-trip" do
+    it "re-parses shorthand-only names emitted via the block form",
+       :aggregate_failures do
+      src = <<~LUTAML
+        diagram D {
+          Foo::Bar --> Baz::Qux
+          A#x.y o--> B#other:role [0..*]
+        }
+      LUTAML
+      document = reparse(src)
+
+      reparsed = reparse(document.to_lutaml)
+
+      expect(association_tuples(reparsed)).to eq(association_tuples(document))
+      expect(reparsed.associations.first.owner_end).to eq("Foo::Bar")
+      expect(reparsed.associations.first.member_end).to eq("Baz::Qux")
     end
   end
 end

--- a/spec/lutaml/converter/uml_to_dsl_spec.rb
+++ b/spec/lutaml/converter/uml_to_dsl_spec.rb
@@ -96,4 +96,16 @@ RSpec.describe Lutaml::Converter::UmlToDsl do
       expect(association_tuples(reparsed)).to eq(association_tuples(document))
     end
   end
+
+  describe "definition escaping round-trip" do
+    it "round-trips a definition containing backslashes and braces" do
+      tricky = 'a backslash \\ and braces { } and a \\{ combo'
+      document = Lutaml::Uml::Document.new(name: "M")
+      document.classes = [Lutaml::Uml::Class.new(name: "C", definition: tricky)]
+
+      reparsed = reparse(document.to_lutaml)
+
+      expect(reparsed.classes.first.definition).to eq(tricky)
+    end
+  end
 end

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -225,6 +225,22 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
         expect(roles.member_end_cardinality.max).to eq("*")
       end
 
+      it "consumes role-name visibility markers without a merge collision",
+         :aggregate_failures do
+        # `#+role` / `#-other` previously raised a "Duplicate subtrees" warning
+        # and dropped the prefix; the marker is now consumed, leaving clean
+        # role names on both ends.
+        file = Tempfile.new(["role_visibility", ".lutaml"])
+        file.write("diagram V {\n  A#+role --> B#-other\n}")
+        file.flush
+        assoc = described_class.parse(File.new(file.path)).associations.first
+        expect(assoc.owner_end_attribute_name).to eq("role")
+        expect(assoc.member_end_attribute_name).to eq("other")
+      ensure
+        file&.close
+        file&.unlink
+      end
+
       it "keeps qualified endpoint names intact (operator-aware token)" do
         expect(ends[10]).to eq(["Foo::Bar", nil, "Baz::Qux", "direct"])
       end
@@ -243,6 +259,17 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
           file&.close
           file&.unlink
         end
+      end
+
+      it "accepts a tab around the operator, not only spaces" do
+        file = Tempfile.new(["tabbed", ".lutaml"])
+        file.write("diagram V {\n  A\t-->\tB\n}")
+        file.flush
+        expect(described_class.parse(File.new(file.path)).associations.length)
+          .to eq(1)
+      ensure
+        file&.close
+        file&.unlink
       end
 
       it_behaves_like "the correct graphviz formatting"

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tempfile"
 
 RSpec.describe Lutaml::Uml::Parsers::Dsl do
   describe ".parse" do
@@ -184,6 +185,67 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
           expect(association.member_end_cardinality).to(be_nil)
         end
       end
+    end
+
+    context "when one-line association shorthand exists" do
+      let(:content) do
+        File.new(fixtures_path("dsl/diagram_class_association_shorthand.lutaml"))
+      end
+
+      let(:ends) do
+        parse.associations.map do |a|
+          [a.owner_end, a.owner_end_type, a.member_end, a.member_end_type]
+        end
+      end
+
+      it "parses every operator form into the right number of associations" do
+        expect(parse.associations.length).to eq(11)
+      end
+
+      it "maps each operator to the correct end types", :aggregate_failures do
+        expect(ends[0]).to eq(["A", nil, "B", "direct"])         # A --> B
+        expect(ends[1]).to eq(["A", "aggregation", "B", nil])    # A o-- B
+        expect(ends[2]).to eq(["A", "composition", "B", nil])    # A *-- B
+        expect(ends[3]).to eq(["A", nil, "B", "inheritance"])    # A --|> B
+        expect(ends[4]).to eq(["A", "aggregation", "B", "direct"]) # A o--> B (dual)
+        expect(ends[5]).to eq(["A", nil, "B", nil])              # A -- B
+        expect(ends[6]).to eq(["A", "direct", "B", nil])         # A <-- B (left direct)
+        expect(ends[7]).to eq(["A", "inheritance", "B", nil])    # A <|-- B (left inheritance)
+        expect(ends[8]).to eq(["A", nil, "B", "aggregation"])    # A --o B (right aggregation)
+      end
+
+      it "supports role names and cardinality on both ends", :aggregate_failures do
+        roles = parse.associations[9]
+        expect(roles.owner_end).to eq("A")
+        expect(roles.owner_end_attribute_name).to eq("owns")
+        expect(roles.owner_end_cardinality.min).to eq("1")
+        expect(roles.member_end).to eq("B")
+        expect(roles.member_end_attribute_name).to eq("owned")
+        expect(roles.member_end_cardinality.min).to eq("0")
+        expect(roles.member_end_cardinality.max).to eq("*")
+      end
+
+      it "keeps qualified endpoint names intact (operator-aware token)" do
+        expect(ends[10]).to eq(["Foo::Bar", nil, "Baz::Qux", "direct"])
+      end
+
+      it "requires whitespace around the operator (rejects spaceless forms)",
+         :aggregate_failures do
+        # `Foo-->Bar` would otherwise mis-parse `Foo`'s trailing `o` as an
+        # `o--` aggregation adornment, so the spaceless form is rejected.
+        %w[Foo-->Bar A--order A--oB].each do |spaceless|
+          file = Tempfile.new(["spaceless", ".lutaml"])
+          file.write("diagram V {\n  #{spaceless}\n}")
+          file.flush
+          expect { described_class.parse(File.new(file.path)) }
+            .to raise_error(Lutaml::Uml::Parsers::ParsingError)
+        ensure
+          file&.close
+          file&.unlink
+        end
+      end
+
+      it_behaves_like "the correct graphviz formatting"
     end
 
     context "when data_types entries" do


### PR DESCRIPTION
This PR adds **single-line association syntax** to the LutaML DSL and the ability to export a model back to LutaML DSL.

This PR:
- Adds PlantUML-style one-line association arrows (`A --> B`, `A o--> B`, `A *-- B`, `A --|> B`), parsed compositionally, with optional role names and cardinality (`A#role[1] --> B#other[0..*]`) and qualified endpoints (`Foo::Bar --> Baz::Qux`). The shorthand desugars to the same structure as the `association { }` block, so the converter and model are untouched.
- Adds `Document#to_lutaml` (via `Lutaml::Converter::UmlToDsl`) to export a UML document back to LutaML DSL, round-tripping through the parser.
- Documents the single-line syntax and corrects the association role keywords in `lutaml-syntax.adoc` (`owned_type`/`owned` → `owner_type`/`owner`, matching the grammar).

related to #37
