### PR TITLE
[WIP] feat: add XSD and JSON Schema realization

### DIFF
--- a/lib/lutaml.rb
+++ b/lib/lutaml.rb
@@ -15,4 +15,5 @@ module Lutaml
   autoload :Qea, "lutaml/qea"
   autoload :Converter, "lutaml/converter"
   autoload :ModelTransformations, "lutaml/model_transformations"
+  autoload :Schema, "lutaml/schema"
 end

--- a/lib/lutaml/cli/uml/export_command.rb
+++ b/lib/lutaml/cli/uml/export_command.rb
@@ -43,6 +43,8 @@ module Lutaml
           when "xsd", "json-schema" then run_schema(repo)
           else raise Thor::Error, "Unknown format: #{options[:format]}"
           end
+        rescue Thor::Error
+          raise
         rescue StandardError => e
           fail_export(e)
         end

--- a/lib/lutaml/cli/uml/export_command.rb
+++ b/lib/lutaml/cli/uml/export_command.rb
@@ -18,48 +18,91 @@ module Lutaml
           Examples:
             lutaml uml export model.lur --format json -o model.json
             lutaml uml export model.lur --format markdown -o docs/
+            lutaml uml export model.lur --format xsd --class Building -o b.xsd
+            lutaml uml export model.lur --format json-schema --class Building -o b.json
           DESC
 
           thor_class.option :format, type: :string, required: true,
-                                     desc: "Export format (json|markdown)"
+                                     desc: "Export format " \
+                                           "(json|markdown|xsd|json-schema)"
           thor_class.option :output, aliases: "-o", required: true,
                                      desc: "Output path"
+          thor_class.option :class, type: :string,
+                                    desc: "Class to realize " \
+                                          "(required for xsd|json-schema)"
           thor_class.option :package, type: :string, desc: "Filter by package"
           thor_class.option :recursive, type: :boolean, default: true,
                                         desc: "Include nested packages"
         end
 
-        def run(lur_path) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+        def run(lur_path)
           repo = load_repository(lur_path)
 
-          exporter_class = case options[:format].downcase
-                           when "json"
-                             Lutaml::UmlRepository::Exporters::JsonExporter
-                           when "markdown"
-                             Lutaml::UmlRepository::Exporters::MarkdownExporter
-                           else
-                             puts OutputFormatter.error(
-                               "Unknown format: #{options[:format]}",
-                             )
-                             raise Thor::Error,
-                                   "Unknown format: #{options[:format]}"
-                           end
-
-          exporter = exporter_class.new(repo)
-
-          OutputFormatter.progress("Exporting to #{options[:format]}")
-          exporter.export(options[:output],
-                          options.to_h.transform_keys(&:to_sym))
-          OutputFormatter.progress_done
-
-          puts OutputFormatter.success("Exported to #{options[:output]}")
+          case options[:format].downcase
+          when "json", "markdown" then run_exporter(repo)
+          when "xsd", "json-schema" then run_schema(repo)
+          else raise Thor::Error, "Unknown format: #{options[:format]}"
+          end
         rescue StandardError => e
-          OutputFormatter.progress_done(success: false)
-          puts OutputFormatter.error("Export failed: #{e.message}")
-          raise Thor::Error, "Export failed: #{e.message}"
+          fail_export(e)
         end
 
         private
+
+        def run_exporter(repo)
+          with_progress do
+            exporter_class.new(repo).export(
+              options[:output], options.to_h.transform_keys(&:to_sym)
+            )
+          end
+        end
+
+        # Schema realization (XSD / JSON Schema) via the lutaml-model bridge.
+        def run_schema(repo)
+          bridge = Lutaml::Schema::Bridge.new(repo.document)
+          class_name = realization_class!(bridge)
+          with_progress do
+            File.write(options[:output], schema_content(bridge, class_name))
+          end
+        end
+
+        def exporter_class
+          if options[:format].casecmp?("json")
+            Lutaml::UmlRepository::Exporters::JsonExporter
+          else
+            Lutaml::UmlRepository::Exporters::MarkdownExporter
+          end
+        end
+
+        def schema_content(bridge, class_name)
+          if options[:format].casecmp?("xsd")
+            bridge.to_xsd(class_name)
+          else
+            bridge.to_json_schema(class_name)
+          end
+        end
+
+        def realization_class!(bridge)
+          class_name = options[:class]
+          return class_name if class_name && !class_name.empty?
+
+          raise Thor::Error,
+                "--class is required for #{options[:format]} " \
+                "(available: #{bridge.class_names.sort.join(', ')})"
+        end
+
+        def with_progress
+          OutputFormatter.progress("Exporting to #{options[:format]}")
+          yield
+          OutputFormatter.progress_done
+          puts OutputFormatter.success("Exported to #{options[:output]}")
+        end
+
+        def fail_export(error)
+          OutputFormatter.progress_done(success: false)
+          puts OutputFormatter.error("Export failed: #{error.message}")
+          raise Thor::Error, "Export failed: #{error.message}"
+        end
 
         def load_repository(lur_path, lazy: false)
           OutputFormatter.progress("Loading repository from #{lur_path}")

--- a/lib/lutaml/schema.rb
+++ b/lib/lutaml/schema.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Lutaml
+  # Schema realization: generate XSD / JSON Schema from a UML
+  # {Lutaml::Uml::Document} by synthesizing lutaml-model Serializable classes
+  # and bridging to lutaml-model's emitters. Which attribute becomes an XML
+  # attribute vs element, and element ordering, are decided by an
+  # {Lutaml::Schema::EncodingRule} reading generic tagged values on the model
+  # (so the same model can target different schema languages).
+  module Schema
+    autoload :Bridge, "lutaml/schema/bridge"
+    autoload :EncodingRule, "lutaml/schema/encoding_rule"
+  end
+end

--- a/lib/lutaml/schema/bridge.rb
+++ b/lib/lutaml/schema/bridge.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+require_relative "encoding_rule"
+
+module Lutaml
+  module Schema
+    # Bridges a UML {Lutaml::Uml::Document} to lutaml-model's schema emitters.
+    #
+    # For each UML class it synthesizes a lutaml-model +Serializable+ subclass
+    # whose attributes and +xml do ... end+ mapping are derived from the class's
+    # attributes via an {EncodingRule}, then delegates to lutaml-model:
+    # +to_xsd+ for XSD and JSON Schema generation. The synthesized class is
+    # given a real +name+ (anonymous classes crash JSON Schema generation).
+    #
+    # @example
+    #   bridge = Lutaml::Schema::Bridge.new(repository.document)
+    #   File.write("address.xsd", bridge.to_xsd("Address"))
+    #   File.write("address.json", bridge.to_json_schema("Address"))
+    class Bridge
+      # UML primitive name => lutaml-model type symbol. Unknown types (including
+      # references to other classes) fall back to string for now; richer type
+      # realization is a follow-up.
+      PRIMITIVE_TYPES = {
+        "string" => :string, "integer" => :integer, "int" => :integer,
+        "boolean" => :boolean, "bool" => :boolean, "float" => :float,
+        "double" => :float, "real" => :float, "decimal" => :decimal,
+        "date" => :date
+      }.freeze
+
+      # An XML NCName (no namespace colon): a UML attribute name must be one to
+      # be realized as an element/attribute name.
+      NCNAME = /\A[A-Za-z_][\w.-]*\z/
+
+      def initialize(document, encoding_rule: EncodingRule.new)
+        @document = document
+        @encoding_rule = encoding_rule
+        @synthesized = {}
+      end
+
+      # @return [Array<String>] names of UML classes the bridge can realize
+      def class_names
+        uml_classes.filter_map(&:name)
+      end
+
+      # @param class_name [String] the UML class to realize
+      # @return [String] the XSD document
+      def to_xsd(class_name)
+        require "lutaml/xml"
+        Lutaml::Model::Schema.to_xsd(serializable_for(class_name))
+      end
+
+      # @param class_name [String] the UML class to realize
+      # @return [String] the (pretty) JSON Schema document
+      def to_json_schema(class_name)
+        Lutaml::Json::Schema::JsonSchema.generate(
+          serializable_for(class_name), pretty: true
+        )
+      end
+
+      # Ruby attribute name / XML node name for a UML attribute. The UML name is
+      # used VERBATIM (not sanitized): lutaml-model's XSD emitter derives an
+      # element's name from the Ruby attribute key, not the mapping name, so
+      # sanitizing here would corrupt element names. Names are validated as XML
+      # NCNames before a class is synthesized. Public for the synthesized-class
+      # closures.
+      def attr_key(attribute)
+        xml_name(attribute).to_sym
+      end
+
+      def xml_name(attribute)
+        attribute.name.to_s.strip
+      end
+
+      # lutaml-model type symbol for a UML attribute's declared type.
+      def primitive_for(attribute)
+        PRIMITIVE_TYPES.fetch(attribute.type.to_s.strip.downcase, :string)
+      end
+
+      private
+
+      def serializable_for(class_name)
+        uml = uml_class(class_name)
+        unless uml
+          raise ArgumentError,
+                "No class named #{class_name.inspect}. " \
+                "Available: #{class_names.uniq.sort.join(', ')}"
+        end
+
+        @synthesized[uml.name] ||= build_serializable(uml)
+      end
+
+      def build_serializable(uml) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+        classified = @encoding_rule.classify(realizable_attributes(uml))
+        elements = classified[:elements]
+        xml_attributes = classified[:attributes]
+        name = uml.name
+        bridge = self
+
+        ::Class.new(Lutaml::Model::Serializable) do
+          (elements + xml_attributes).each do |field|
+            attribute bridge.attr_key(field), bridge.primitive_for(field)
+          end
+
+          xml do
+            root name
+            elements.each do |field|
+              map_element bridge.xml_name(field), to: bridge.attr_key(field)
+            end
+            xml_attributes.each do |field|
+              map_attribute bridge.xml_name(field), to: bridge.attr_key(field)
+            end
+          end
+
+          # Anonymous classes have name == nil, which crashes JSON Schema
+          # generation (nil.gsub); give the synthesized class the UML name.
+          define_singleton_method(:name) { name }
+        end
+      end
+
+      # Attributes we can realize: drop blank-named ones, then fail loudly on
+      # names that are not valid XML names or that collide, rather than emit a
+      # silently wrong schema.
+      def realizable_attributes(uml)
+        attributes = (uml.attributes || []).to_a
+          .reject { |attribute| attribute.name.to_s.strip.empty? }
+        names = attributes.map { |attribute| attribute.name.to_s.strip }
+        validate_xml_names!(uml, names)
+        validate_unique_names!(uml, names)
+        attributes
+      end
+
+      def validate_xml_names!(uml, names)
+        invalid = names.grep_v(NCNAME)
+        return if invalid.empty?
+
+        raise ArgumentError,
+              "Class #{uml.name.inspect} has attribute name(s) that are not " \
+              "valid XML names: #{invalid.join(', ')}"
+      end
+
+      def validate_unique_names!(uml, names)
+        duplicates = names.tally.select { |_name, count| count > 1 }.keys
+        return if duplicates.empty?
+
+        raise ArgumentError,
+              "Class #{uml.name.inspect} has duplicate attribute name(s): " \
+              "#{duplicates.join(', ')}"
+      end
+
+      def uml_classes
+        @uml_classes ||= collect_classes(@document)
+      end
+
+      # Realizing by simple name; duplicate simple names across packages are
+      # ambiguous (qualified-name selection is a follow-up).
+      def uml_class(class_name)
+        matches = uml_classes.select { |klass| klass.name == class_name }
+        if matches.size > 1
+          raise ArgumentError,
+                "#{matches.size} classes are named #{class_name.inspect}; the " \
+                "bridge cannot disambiguate them by simple name."
+        end
+        matches.first
+      end
+
+      # UML classes across the whole package tree (Document/Package both expose
+      # +classes+ and +packages+).
+      def collect_classes(container)
+        direct = (container.classes || []).to_a
+        nested = (container.packages || []).to_a
+          .flat_map { |package| collect_classes(package) }
+        direct + nested
+      end
+    end
+  end
+end

--- a/lib/lutaml/schema/bridge.rb
+++ b/lib/lutaml/schema/bridge.rb
@@ -10,8 +10,10 @@ module Lutaml
     # For each UML class it synthesizes a lutaml-model +Serializable+ subclass
     # whose attributes and +xml do ... end+ mapping are derived from the class's
     # attributes via an {EncodingRule}, then delegates to lutaml-model:
-    # +to_xsd+ for XSD and JSON Schema generation. The synthesized class is
-    # given a real +name+ (anonymous classes crash JSON Schema generation).
+    # +Lutaml::Model::Schema.to_xsd+ for XSD and
+    # +Lutaml::Json::Schema::JsonSchema.generate+ for JSON Schema. The
+    # synthesized class is given a real +name+ (anonymous classes crash JSON
+    # Schema generation).
     #
     # @example
     #   bridge = Lutaml::Schema::Bridge.new(repository.document)
@@ -53,6 +55,7 @@ module Lutaml
       # @param class_name [String] the UML class to realize
       # @return [String] the (pretty) JSON Schema document
       def to_json_schema(class_name)
+        require "lutaml/json"
         Lutaml::Json::Schema::JsonSchema.generate(
           serializable_for(class_name), pretty: true
         )

--- a/lib/lutaml/schema/bridge.rb
+++ b/lib/lutaml/schema/bridge.rb
@@ -91,6 +91,7 @@ module Lutaml
       end
 
       def build_serializable(uml) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+        validate_class_name!(uml)
         classified = @encoding_rule.classify(realizable_attributes(uml))
         elements = classified[:elements]
         xml_attributes = classified[:attributes]
@@ -146,6 +147,18 @@ module Lutaml
         raise ArgumentError,
               "Class #{uml.name.inspect} has duplicate attribute name(s): " \
               "#{duplicates.join(', ')}"
+      end
+
+      # The class name becomes the XSD root element name and the JSON Schema
+      # definition/$ref key, so it must be a valid XML name too (attribute
+      # names are already validated in #realizable_attributes). Fail loudly
+      # rather than emit an invalid schema or an unescaped $ref.
+      def validate_class_name!(uml)
+        return if uml.name.to_s.match?(NCNAME)
+
+        raise ArgumentError,
+              "Class #{uml.name.inspect} is not a valid XML name and cannot " \
+              "be realized as an XSD root / JSON Schema definition name."
       end
 
       def uml_classes

--- a/lib/lutaml/schema/bridge.rb
+++ b/lib/lutaml/schema/bridge.rb
@@ -30,9 +30,11 @@ module Lutaml
         "date" => :date
       }.freeze
 
-      # An XML NCName (no namespace colon): a UML attribute name must be one to
-      # be realized as an element/attribute name.
-      NCNAME = /\A[A-Za-z_][\w.-]*\z/
+      # An XML NCName (no namespace colon): a UML class/attribute name must be
+      # one to be realized as an element/attribute name. Unicode-aware
+      # approximation of the XML 1.0 NCName production (letters, digits,
+      # combining marks, plus `_ . -`), so non-ASCII names like "Gebäude" pass.
+      NCNAME = /\A[\p{L}_][\p{L}\p{M}\p{Nd}._-]*\z/
 
       def initialize(document, encoding_rule: EncodingRule.new)
         @document = document
@@ -80,6 +82,20 @@ module Lutaml
         PRIMITIVE_TYPES.fetch(attribute.type.to_s.strip.downcase, :string)
       end
 
+      # Realize UML multiplicity: a max cardinality above 1 becomes a
+      # lutaml-model collection (JSON Schema: array with minItems/maxItems;
+      # XSD: minOccurs/maxOccurs). An unbounded "*" keeps no lower bound —
+      # lutaml-model collections take true or a finite Range. Bounds are
+      # free text from the source model; {#validate_multiplicity_bounds!}
+      # rejects unrecognized tokens before any class is synthesized.
+      def collection_options(attribute)
+        max = attribute.cardinality&.max.to_s.strip
+        return {} if max.empty? || %w[0 1].include?(max)
+        return { collection: true } if max == "*"
+
+        { collection: (attribute.cardinality.min.to_s.strip.to_i..max.to_i) }
+      end
+
       private
 
       def serializable_for(class_name)
@@ -95,15 +111,20 @@ module Lutaml
 
       def build_serializable(uml) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
         validate_class_name!(uml)
-        classified = @encoding_rule.classify(realizable_attributes(uml))
+        fields = realizable_attributes(uml)
+        validate_multiplicity_bounds!(uml, fields)
+        classified = @encoding_rule.classify(fields)
         elements = classified[:elements]
         xml_attributes = classified[:attributes]
         name = uml.name
         bridge = self
 
+        validate_attribute_multiplicities!(uml, xml_attributes)
+
         ::Class.new(Lutaml::Model::Serializable) do
           (elements + xml_attributes).each do |field|
-            attribute bridge.attr_key(field), bridge.primitive_for(field)
+            attribute bridge.attr_key(field), bridge.primitive_for(field),
+                      **bridge.collection_options(field)
           end
 
           xml do
@@ -150,6 +171,56 @@ module Lutaml
         raise ArgumentError,
               "Class #{uml.name.inspect} has duplicate attribute name(s): " \
               "#{duplicates.join(', ')}"
+      end
+
+      # Multiplicity bounds arrive as free text from the source model (QEA
+      # passes t_attribute columns through unmodified; XMI passes upper_value
+      # raw), so tokens like "n", "-1" or inverted ranges can reach the
+      # bridge. Reject them naming the class and attribute, rather than emit
+      # a maxItems: 0 schema or let lutaml-model raise an anonymous range
+      # error from inside the synthesized class.
+      def validate_multiplicity_bounds!(uml, attributes)
+        bad = attributes.reject { |field| valid_bounds?(field.cardinality) }
+        return if bad.empty?
+
+        bounds = bad.map do |field|
+          "#{xml_name(field)} (#{field.cardinality.min}..#{field.cardinality.max})"
+        end
+        raise ArgumentError,
+              "Class #{uml.name.inspect} has attribute(s) with unrecognized " \
+              "or inverted multiplicity bounds: #{bounds.join(', ')}"
+      end
+
+      # A max bound must be "*" or a non-negative integer. Min is validated
+      # whenever max is a finite integer — including 0/1, where a garbage or
+      # inverted min still indicates a broken source model even though no
+      # collection Range is built. Only a blank or "*" max skips min
+      # validation: an unbounded max ignores min by design.
+      def valid_bounds?(cardinality)
+        max = cardinality&.max.to_s.strip
+        return true if max.empty? || max == "*"
+
+        max.match?(/\A\d+\z/) && valid_min?(cardinality.min, max)
+      end
+
+      def valid_min?(raw_min, max)
+        min = raw_min.to_s.strip
+        min.empty? || (min.match?(/\A\d+\z/) && min.to_i <= max.to_i)
+      end
+
+      # An XML attribute cannot repeat, so a multi-valued UML attribute tagged
+      # xmlAttribute cannot be realized. Fail loudly rather than emit a schema
+      # that silently drops the multiplicity.
+      def validate_attribute_multiplicities!(uml, xml_attributes)
+        multi = xml_attributes.reject do |field|
+          collection_options(field).empty?
+        end
+        return if multi.empty?
+
+        names = multi.map { |field| xml_name(field) }
+        raise ArgumentError,
+              "Class #{uml.name.inspect} has multi-valued attribute(s) tagged " \
+              "xmlAttribute (an XML attribute cannot repeat): #{names.join(', ')}"
       end
 
       # The class name becomes the XSD root element name and the JSON Schema

--- a/lib/lutaml/schema/encoding_rule.rb
+++ b/lib/lutaml/schema/encoding_rule.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Schema
+    # Decides how a UML class's attributes are realized in XML, reading generic
+    # tagged values on each attribute:
+    #
+    # - +xmlAttribute+ (truthy: true/yes/1) -> rendered as an XSD +<attribute>+
+    # - +sequenceNumber+ (an integer)       -> element ordering, ascending
+    #
+    # Everything without +xmlAttribute+ is an +<element>+; elements without a
+    # +sequenceNumber+ keep their declaration order, after the numbered ones.
+    # +sequenceNumber+ is the conventional Enterprise Architect / ShapeChange
+    # tag. This is the default rule; a different one can be injected into
+    # {Bridge} to support other conventions without touching the model.
+    class EncodingRule
+      ATTRIBUTE_TAG = "xmlAttribute"
+      SEQUENCE_TAG = "sequenceNumber"
+      TRUTHY = %w[true yes 1].freeze
+
+      # Partition and order a class's attributes.
+      #
+      # @param attributes [Enumerable, nil] the UML attributes
+      # @return [Hash] +{ elements: [ordered attrs], attributes: [attrs] }+
+      def classify(attributes)
+        list = attributes ? attributes.to_a : []
+        xml_attributes, elements = list.each_with_index.to_a
+          .partition { |(attribute, _index)| xml_attribute?(attribute) }
+        {
+          elements: order_elements(elements),
+          attributes: xml_attributes.map(&:first),
+        }
+      end
+
+      # @return [Boolean] whether the attribute is tagged as an XML attribute
+      def xml_attribute?(attribute)
+        value = tag_value(attribute, ATTRIBUTE_TAG)
+        TRUTHY.include?(value.to_s.strip.downcase)
+      end
+
+      private
+
+      # Stable: by sequenceNumber ascending, then declaration order.
+      def order_elements(indexed_elements)
+        indexed_elements.sort_by do |(attribute, index)|
+          [sequence_number(attribute) || Float::INFINITY, index]
+        end.map(&:first)
+      end
+
+      def sequence_number(attribute)
+        Integer(tag_value(attribute, SEQUENCE_TAG).to_s.strip, exception: false)
+      end
+
+      def tag_value(attribute, name)
+        tags = attribute.tagged_values
+        return nil unless tags
+
+        tags.find { |tagged_value| tagged_value.name == name }&.value
+      end
+    end
+  end
+end

--- a/spec/lutaml/cli/uml/export_command_spec.rb
+++ b/spec/lutaml/cli/uml/export_command_spec.rb
@@ -46,5 +46,60 @@ RSpec.describe Lutaml::Cli::Uml::ExportCommand do
         expect { command.run(test_lur) }.to raise_error(/Unknown format/)
       end
     end
+
+    context "schema realization" do
+      let(:schema_lur) do
+        path = temp_lur_path(prefix: "schema_export")
+        address = Lutaml::Uml::Class.new(
+          name: "Address",
+          attributes: [
+            Lutaml::Uml::TopElementAttribute.new(
+              name: "id", type: "String",
+              tagged_values: [
+                Lutaml::Uml::TaggedValue.new(name: "xmlAttribute", value: "true"),
+              ]
+            ),
+            Lutaml::Uml::TopElementAttribute.new(
+              name: "street", type: "String",
+              tagged_values: [
+                Lutaml::Uml::TaggedValue.new(name: "sequenceNumber", value: "1"),
+              ]
+            ),
+          ],
+        )
+        document = Lutaml::Uml::Document.new(name: "M", classes: [address])
+        Lutaml::UmlRepository::Repository.new(document: document)
+          .export_to_package(path)
+        path
+      end
+      let(:schema_output) do
+        temp_lur_path(prefix: "schema_output").sub(/\.lur$/, ".xsd")
+      end
+
+      after do
+        FileUtils.rm_f(schema_lur)
+        FileUtils.rm_f(schema_output)
+      end
+
+      context "to XSD with --class" do
+        let(:options) { { format: "xsd", class: "Address", output: schema_output } }
+
+        it "writes an XSD driven by the tagged values", :aggregate_failures do
+          expect { command.run(schema_lur) }.to output(/Exported to/).to_stdout
+          xsd = File.read(schema_output)
+          expect(xsd).to include('<attribute name="id"')
+          expect(xsd).to include('<element name="street"')
+        end
+      end
+
+      context "without --class" do
+        let(:options) { { format: "json-schema", output: schema_output } }
+
+        it "fails asking for a class to realize" do
+          expect { command.run(schema_lur) }
+            .to raise_error(/--class is required/)
+        end
+      end
+    end
   end
 end

--- a/spec/lutaml/schema/bridge_spec.rb
+++ b/spec/lutaml/schema/bridge_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe Lutaml::Schema::Bridge do
         .to raise_error(ArgumentError, /duplicate attribute name/)
     end
 
+    it "rejects a class name that is not a valid XML name",
+       :aggregate_failures do
+      doc = Lutaml::Uml::Document.new(
+        name: "M",
+        classes: [Lutaml::Uml::Class.new(
+          name: "Bad Class", attributes: [attribute("id", "String")],
+        )],
+      )
+      expect { described_class.new(doc).to_xsd("Bad Class") }
+        .to raise_error(ArgumentError, /not a valid XML name/)
+      expect { described_class.new(doc).to_json_schema("Bad Class") }
+        .to raise_error(ArgumentError, /not a valid XML name/)
+    end
+
     it "refuses to disambiguate duplicate simple class names" do
       pkg = Lutaml::Uml::Package.new(
         name: "P",

--- a/spec/lutaml/schema/bridge_spec.rb
+++ b/spec/lutaml/schema/bridge_spec.rb
@@ -69,12 +69,128 @@ RSpec.describe Lutaml::Schema::Bridge do
     end
   end
 
+  describe "cardinality realization" do
+    def attribute_with_cardinality(name, type, min, max, tags = {})
+      attr = attribute(name, type, tags)
+      attr.cardinality = Lutaml::Uml::Cardinality.new(min: min, max: max)
+      attr
+    end
+
+    let(:document) do
+      Lutaml::Uml::Document.new(
+        name: "M",
+        classes: [Lutaml::Uml::Class.new(
+          name: "House",
+          attributes: [
+            attribute_with_cardinality("rooms", "String", "0", "*"),
+            attribute_with_cardinality("owners", "String", "1", "3"),
+            attribute("name", "String"),
+          ],
+        )],
+      )
+    end
+
+    it "realizes multi-valued attributes as XSD repeats", :aggregate_failures do
+      xsd = bridge.to_xsd("House")
+      expect(xsd).to include('name="rooms" minOccurs="0" maxOccurs="unbounded"')
+      # The repeat itself is what the bridge guarantees; lutaml-model's XSD
+      # emitter currently collapses finite bounds to 0..unbounded (the JSON
+      # Schema output below carries the true 1..3), an upstream limitation.
+      expect(xsd).to match(/name="owners" minOccurs="\d+" maxOccurs=/)
+      # single-valued stays a plain scalar element
+      expect(xsd).to include('<element name="name" type="xs:string"/>')
+    end
+
+    it "realizes multi-valued attributes as JSON arrays", :aggregate_failures do
+      props = JSON.parse(bridge.to_json_schema("House"))
+        .dig("$defs", "House", "properties")
+      expect(props.dig("rooms", "type")).to eq("array")
+      expect(props.dig("owners", "type")).to eq("array")
+      expect(props.dig("owners", "minItems")).to eq(1)
+      expect(props.dig("owners", "maxItems")).to eq(3)
+      # positive shape, so a dropped property cannot false-pass a negation
+      expect(props.dig("name", "type")).to eq(%w[string null])
+    end
+
+    it "rejects a multi-valued attribute tagged xmlAttribute" do
+      doc = Lutaml::Uml::Document.new(
+        name: "M",
+        classes: [Lutaml::Uml::Class.new(
+          name: "X",
+          attributes: [attribute_with_cardinality("ids", "String", "0", "*",
+                                                  xmlAttribute: "true")],
+        )],
+      )
+      expect { described_class.new(doc).to_xsd("X") }
+        .to raise_error(ArgumentError, /cannot repeat.*ids/m)
+    end
+
+    # EA/XMI multiplicity bounds are free text; they must fail loudly with
+    # the class and attribute named, not become a maxItems:0 schema or an
+    # anonymous lutaml-model range error.
+    context "with free-text bounds from the source model" do
+      def bridge_for(min, max)
+        described_class.new(Lutaml::Uml::Document.new(
+                              name: "M",
+                              classes: [Lutaml::Uml::Class.new(
+                                name: "X",
+                                attributes: [attribute_with_cardinality(
+                                  "ids", "String", min, max
+                                )],
+                              )],
+                            ))
+      end
+
+      it "recognizes a padded \"*\" as unbounded" do
+        expect(bridge_for("0", "* ").to_xsd("X"))
+          .to include('name="ids" minOccurs="0" maxOccurs="unbounded"')
+      end
+
+      it "rejects an unrecognized max token, naming the attribute" do
+        expect { bridge_for("0", "n").to_xsd("X") }
+          .to raise_error(ArgumentError,
+                          /Class "X".*multiplicity bounds: ids \(0\.\.n\)/m)
+      end
+
+      it "rejects a negative max bound" do
+        expect { bridge_for("0", "-1").to_xsd("X") }
+          .to raise_error(ArgumentError, /ids \(0\.\.-1\)/)
+      end
+
+      it "rejects inverted bounds" do
+        expect { bridge_for("5", "3").to_xsd("X") }
+          .to raise_error(ArgumentError, /ids \(5\.\.3\)/)
+      end
+
+      it "validates min even when a scalar max makes it unused" do
+        expect { bridge_for("x", "1").to_xsd("X") }
+          .to raise_error(ArgumentError, /ids \(x\.\.1\)/)
+      end
+
+      it "ignores min when max is unbounded" do
+        expect(bridge_for("x", "*").to_xsd("X"))
+          .to include('name="ids" minOccurs="0" maxOccurs="unbounded"')
+      end
+    end
+  end
+
   describe "name handling" do
     def document_with(*attributes)
       Lutaml::Uml::Document.new(
         name: "M",
         classes: [Lutaml::Uml::Class.new(name: "X", attributes: attributes)],
       )
+    end
+
+    it "accepts non-ASCII NCNames for classes and attributes" do
+      doc = Lutaml::Uml::Document.new(
+        name: "M",
+        classes: [Lutaml::Uml::Class.new(
+          name: "Gebäude", attributes: [attribute("straße", "String")],
+        )],
+      )
+      expect(described_class.new(doc).to_xsd("Gebäude"))
+        .to include('<element name="straße"')
     end
 
     it "uses a hyphenated UML name verbatim as the element name" do

--- a/spec/lutaml/schema/bridge_spec.rb
+++ b/spec/lutaml/schema/bridge_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require_relative "../../../lib/lutaml/schema/bridge"
+
+RSpec.describe Lutaml::Schema::Bridge do
+  def attribute(name, type, tags = {})
+    Lutaml::Uml::TopElementAttribute.new(
+      name: name, type: type,
+      tagged_values: tags.map do |key, value|
+        Lutaml::Uml::TaggedValue.new(name: key.to_s, value: value.to_s)
+      end
+    )
+  end
+
+  let(:document) do
+    address = Lutaml::Uml::Class.new(
+      name: "Address",
+      attributes: [
+        attribute("id", "String", xmlAttribute: "true"),
+        attribute("street", "String", sequenceNumber: 2),
+        attribute("city", "String", sequenceNumber: 1),
+        attribute("postcode", "Integer"),
+      ],
+    )
+    inner = Lutaml::Uml::Package.new(
+      name: "Inner",
+      classes: [Lutaml::Uml::Class.new(name: "Nested", attributes: [])],
+    )
+    Lutaml::Uml::Document.new(name: "M", classes: [address], packages: [inner])
+  end
+
+  let(:bridge) { described_class.new(document) }
+
+  describe "#class_names" do
+    it "collects classes across the whole package tree" do
+      expect(bridge.class_names).to contain_exactly("Address", "Nested")
+    end
+  end
+
+  describe "#to_xsd" do
+    let(:xsd) { bridge.to_xsd("Address") }
+
+    it "maps xmlAttribute to <attribute> and orders elements by sequenceNumber",
+       :aggregate_failures do
+      expect(xsd).to include('<attribute name="id"')
+      elements = xsd.scan(/<element name="(\w+)"/).flatten
+      # root Address, then city(seq 1), street(seq 2), postcode(unnumbered last)
+      expect(elements).to eq(%w[Address city street postcode])
+      expect(xsd).to include('<attribute name="id" type="xs:string"')
+    end
+  end
+
+  describe "#to_json_schema" do
+    it "produces a draft-2020-12 schema carrying every property",
+       :aggregate_failures do
+      schema = JSON.parse(bridge.to_json_schema("Address"))
+      expect(schema["$schema"]).to include("2020-12")
+      props = schema.dig("$defs", "Address", "properties")
+      expect(props.keys).to contain_exactly("id", "street", "city", "postcode")
+    end
+  end
+
+  describe "an unknown class" do
+    it "raises listing the available class names" do
+      expect { bridge.to_xsd("Nope") }
+        .to raise_error(ArgumentError, /Available: Address, Nested/)
+    end
+  end
+
+  describe "name handling" do
+    def document_with(*attributes)
+      Lutaml::Uml::Document.new(
+        name: "M",
+        classes: [Lutaml::Uml::Class.new(name: "X", attributes: attributes)],
+      )
+    end
+
+    it "uses a hyphenated UML name verbatim as the element name" do
+      doc = document_with(attribute("postal-code", "String", sequenceNumber: 1))
+      expect(described_class.new(doc).to_xsd("X"))
+        .to include('<element name="postal-code"')
+    end
+
+    it "rejects attribute names that are not valid XML names" do
+      doc = document_with(attribute("type/text", "String"))
+      expect { described_class.new(doc).to_xsd("X") }
+        .to raise_error(ArgumentError, %r{not valid XML names: type/text})
+    end
+
+    it "rejects duplicate attribute names" do
+      doc = document_with(attribute("a", "String"), attribute("a", "Integer"))
+      expect { described_class.new(doc).to_xsd("X") }
+        .to raise_error(ArgumentError, /duplicate attribute name/)
+    end
+
+    it "refuses to disambiguate duplicate simple class names" do
+      pkg = Lutaml::Uml::Package.new(
+        name: "P",
+        classes: [Lutaml::Uml::Class.new(name: "Dup", attributes: [])],
+      )
+      doc = Lutaml::Uml::Document.new(
+        name: "M",
+        classes: [Lutaml::Uml::Class.new(name: "Dup", attributes: [])],
+        packages: [pkg],
+      )
+      expect { described_class.new(doc).to_xsd("Dup") }
+        .to raise_error(ArgumentError, /cannot disambiguate/)
+    end
+  end
+end

--- a/spec/lutaml/schema/encoding_rule_spec.rb
+++ b/spec/lutaml/schema/encoding_rule_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/lutaml/schema/encoding_rule"
+
+RSpec.describe Lutaml::Schema::EncodingRule do
+  def attribute(name, tags = {})
+    Lutaml::Uml::TopElementAttribute.new(
+      name: name,
+      tagged_values: tags.map do |key, value|
+        Lutaml::Uml::TaggedValue.new(name: key.to_s, value: value.to_s)
+      end,
+    )
+  end
+
+  let(:attributes) do
+    [
+      attribute("id", xmlAttribute: "true"),
+      attribute("street", sequenceNumber: 2),
+      attribute("city", sequenceNumber: 1),
+      attribute("note"),
+    ]
+  end
+
+  let(:classified) { described_class.new.classify(attributes) }
+
+  it "treats xmlAttribute-tagged attributes as XML attributes" do
+    expect(classified[:attributes].map(&:name)).to eq(["id"])
+  end
+
+  it "orders elements by sequenceNumber, then declaration order",
+     :aggregate_failures do
+    expect(classified[:elements].map(&:name)).to eq(%w[city street note])
+  end
+
+  it "treats only true/yes/1 as an XML attribute", :aggregate_failures do
+    expect(described_class.new.xml_attribute?(attribute("a", xmlAttribute: "true")))
+      .to be(true)
+    expect(described_class.new.xml_attribute?(attribute("b", xmlAttribute: "false")))
+      .to be(false)
+    expect(described_class.new.xml_attribute?(attribute("c"))).to be(false)
+  end
+
+  it "returns empty groups for nil attributes" do
+    expect(described_class.new.classify(nil))
+      .to eq(elements: [], attributes: [])
+  end
+end


### PR DESCRIPTION
This PR adds **XSD** and **JSON Schema** realization from a UML model, reusing LutaML-Model's emitters.

This PR:
- Adds `Lutaml::Schema::Bridge`, which synthesizes a LutaML-Model `Serializable` per UML class and emits XSD or JSON Schema.
- Adds a generic, swappable `EncodingRule` that reads `xmlAttribute` and `sequenceNumber` tagged values to decide attribute-vs-element and element ordering, so no XML syntax is baked into the model.
- Adds `lutaml uml export <lur> --format xsd|json-schema --class NAME` to the CLI.

related to #37
