### PR TITLE
ci: fix rubocop, lychee, and docs Pages checks

### DIFF
--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -1,6 +1,6 @@
 # Lychee link checker configuration for LutaML documentation
 
-# Cache results for 1 day to speed up repeated checks
+# Cache results to speed up repeated checks
 cache = true
 
 # Maximum number of concurrent requests
@@ -12,72 +12,34 @@ timeout = 30
 # Maximum number of retries per link
 max_retries = 3
 
-# Follow redirects
-follow_redirects = true
-
-# Maximum redirect depth
+# Maximum redirect depth (redirects are followed up to this many)
 max_redirects = 5
 
-# Accept status codes
-accept = [
-    200,  # OK
-    203,  # Non-Authoritative Information
-    204,  # No Content
-    206,  # Partial Content
-    429,  # Too Many Requests (we'll retry)
-]
+# Accept these HTTP status codes as success
+accept = [200, 203, 204, 206, 429]
 
-# Exclude patterns (glob format)
+# Exclude URLs matching these regexes
 exclude = [
-    # Exclude localhost links
-    'http://localhost*',
-    'http://127.0.0.1*',
-
-    # Exclude example domains
-    'http://example.com*',
-    'https://example.com*',
-
-    # Exclude GitHub edit links (they may 404 for non-contributors)
-    'https://github.com/*/edit/*',
-
-    # Exclude potential rate-limited APIs
-    'https://api.github.com/*',
+    "^https?://localhost",
+    "^https?://127\\.0\\.0\\.1",
+    "^https?://example\\.com",
+    "^https://github\\.com/[^/]+/[^/]+/edit/",
+    "^https://api\\.github\\.com/",
 ]
 
-# Include patterns - check these file types
-include = [
-    '**/*.html',
-    '**/*.md',
-    '**/*.adoc',
-]
-
-# HTTP headers to send with requests
-[headers]
-# Set user agent
-User-Agent = "Mozilla/5.0 (compatible; Lychee/0.13.0; +https://github.com/lycheeverse/lychee)"
-
-# GitHub API token (if available in environment)
-# Authorization = "Bearer ${GITHUB_TOKEN}"
-
-# Verbose output
-verbose = true
-
-# Don't show progress bar in CI
+# Do not show a progress bar in CI
 no_progress = true
 
 # Output format
 format = "markdown"
 
-# Exclude paths from file system checks
-exclude_path = [
-    ".git/",
-    "_site/",
-    "node_modules/",
-    "vendor/",
-]
+# HTTP headers to send with requests
+header = { "User-Agent" = "Mozilla/5.0 (compatible; Lychee/0.23.0; +https://github.com/lycheeverse/lychee)" }
 
-# Scheme to use when checking local files
-scheme = "https"
+# Schemes to check
+scheme = ["https", "http"]
 
-# Base URL for relative links
-# base = "https://lutaml.github.io/lutaml"
+# Exclude these paths from file-system discovery. NOTE: do not exclude _site/
+# here — the CI link check explicitly targets _site/**/*.html, and excluding it
+# would drop every file ("No files found") and fail with failIfEmpty.
+exclude_path = [".git/", "node_modules/", "vendor/"]

--- a/spec/lutaml/ea/diagram/element_renderers/class_renderer_spec.rb
+++ b/spec/lutaml/ea/diagram/element_renderers/class_renderer_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Lutaml::Ea::Diagram::ElementRenderers::ClassRenderer do
 
         # First attribute should be at y + name_height + 15
         # = 50 + 25 + 15 = 90
-        expect(label).to match(/y="90/)
+        expect(label).to include('y="90')
       end
     end
 

--- a/spec/lutaml/ea/diagram/svg_renderer_spec.rb
+++ b/spec/lutaml/ea/diagram/svg_renderer_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Lutaml::Ea::Diagram::SvgRenderer do
     end
 
     it "applies default background color" do
-      expect(svg_output).to match(/fill:#ffffff/)
+      expect(svg_output).to include("fill:#ffffff")
     end
 
     it "includes fill-opacity style" do

--- a/spec/lutaml/qea/benchmark_spec.rb
+++ b/spec/lutaml/qea/benchmark_spec.rb
@@ -167,8 +167,8 @@ RSpec.describe Lutaml::Qea::Benchmark do
       formatted = described_class.format_results(results)
 
       aggregate_failures do
-        expect(formatted).to match(/faster than XMI/)
-        expect(formatted).to match(/Improvement:/)
+        expect(formatted).to include("faster than XMI")
+        expect(formatted).to include("Improvement:")
       end
     end
 

--- a/spec/lutaml/uml_repository/package_metadata_spec.rb
+++ b/spec/lutaml/uml_repository/package_metadata_spec.rb
@@ -83,28 +83,28 @@ RSpec.describe Lutaml::UmlRepository::PackageMetadata do
       metadata = described_class.new(name: nil, version: "1.0")
       errors = metadata.validate
       expect(errors.size).to eq(1)
-      expect(errors.first.message).to match(/name is required/)
+      expect(errors.first.message).to include("name is required")
     end
 
     it "returns error when name is empty string", :aggregate_failures do
       metadata = described_class.new(name: "", version: "1.0")
       errors = metadata.validate
       expect(errors.size).to eq(1)
-      expect(errors.first.message).to match(/name is required/)
+      expect(errors.first.message).to include("name is required")
     end
 
     it "returns error when version is nil", :aggregate_failures do
       metadata = described_class.new(name: "Test", version: nil)
       errors = metadata.validate
       expect(errors.size).to eq(1)
-      expect(errors.first.message).to match(/version is required/)
+      expect(errors.first.message).to include("version is required")
     end
 
     it "returns error when version is empty string", :aggregate_failures do
       metadata = described_class.new(name: "Test", version: "")
       errors = metadata.validate
       expect(errors.size).to eq(1)
-      expect(errors.first.message).to match(/version is required/)
+      expect(errors.first.message).to include("version is required")
     end
 
     it "returns multiple errors when both required fields missing",
@@ -113,8 +113,8 @@ RSpec.describe Lutaml::UmlRepository::PackageMetadata do
       errors = metadata.validate
       expect(errors.size).to eq(2)
       expect(errors.map(&:message)).to include(
-        match(/name is required/),
-        match(/version is required/),
+        include("name is required"),
+        include("version is required"),
       )
     end
   end


### PR DESCRIPTION
This PR fixes two repo-level CI failures that are present on `main`:

- **RuboCop** — converts `expect(x).to match(/literal/)` to `include(...)` in four spec files. These files are unchanged from `main`; they were newly flagged after RuboCop resolved fresh in CI bumped from `1.86.2` to `1.88.0` (rubocop-rspec `3.10.2`), so `rake`'s rubocop step now fails on them (on every open PR).
- **lychee** — migrates `docs/lychee.toml` to valid lychee **v0.23.0** syntax (the old config used keys that were removed/renamed: `follow_redirects`, the `[headers]` table, string `scheme`/`verbose`, glob `include`), so the link checker no longer fails at config load. Also drops `_site/` from `exclude_path`: CI targets `_site/**/*.html`, so excluding it dropped every file (`"No files found"`) and failed with `failIfEmpty`.
